### PR TITLE
Revert docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:14-alpine
 
 
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM node:19-alpine
-ENV PORT 8080
+FROM node:20-alpine
+
 
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache git
 COPY . .
+
+ENV PORT 8080
 EXPOSE 8080
 CMD ["npm", "start", "--no-update-notifier"]


### PR DESCRIPTION
---
:bulb: Summary generated by FirstMate:
- Dockerfile updated to use Node.js version 14-alpine instead of 19-alpine
- Environment variable PORT set to 8080
- WORKDIR set to /usr/src/app