### PR TITLE
Validate example exist and throw error

### DIFF
--- a/src/services/exampleService.js
+++ b/src/services/exampleService.js
@@ -3,7 +3,11 @@ import exampleRepo from "../repos/exampleRepo.js"
 export class ExampleService {
 
     async getById(id) {
-        return await exampleRepo.getById(id)
+        const example = await exampleRepo.getById(id)
+        if(!example){
+            throw new Error(`Example with ${id} does not exist`)
+        }
+        return example;
     }
 
 


### PR DESCRIPTION
---
:bulb: Summary generated by FirstMate:
- Updated `getById` method in `exampleService.js` to include error handling for non-existent examples.
- Renamed variable from `return` to `example` for clarity.
- Added error throwing mechanism if the example is not found.