### PR TITLE
Demo - [Failed Pipeline] - Add Pod Disruption Budget (with mistake in formatting)

### DIFF
--- a/charts/templates/pdb.yaml
+++ b/charts/templates/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Chart.Name }}-pdb
+spec:
+  minAvailable: 3
+   maxUnavailable: 2
+   selector:
+    matchLabels:
+      app: {{ .Chart.Name }}


### PR DESCRIPTION
### :bulb: PR Summary generated by FirstMate

**Overview**: Added a Pod Disruption Budget (PDB) to enhance application availability during maintenance.

**Changes**:
*New PDB Configuration:*
- Created `/charts/templates/pdb.yaml` to define the Pod Disruption Budget.
- Set `minAvailable` to 3 and `maxUnavailable` to 2 for resource management.
- Utilized chart name for dynamic naming and label matching.

**Formatting Issues:**
- Minor formatting mistakes in indentation within `pdb.yaml`.

**TLDR**: Introduced a Pod Disruption Budget to manage pod availability; focus on the new `pdb.yaml` file.

<sub><sup>Generated by FirstMate and automatically updated on every commit.</sup></sub>